### PR TITLE
Added api specification.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.0'
     id "io.freefair.lombok" version "6.2.0"
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id "org.springdoc.openapi-gradle-plugin" version "1.6.0"
 }
 
 group = 'org.easycontactforms.core'
@@ -30,10 +31,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'org.thymeleaf:thymeleaf:3.0.15.RELEASE'
-    implementation 'jakarta.validation:jakarta.validation-api:2.0.2'
     implementation 'javax.mail:mail:1.5.0-b01'
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
     implementation 'org.glassfish.jaxb:jaxb-runtime'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'

--- a/config/dev.application.properties
+++ b/config/dev.application.properties
@@ -36,3 +36,7 @@ mail.smtp.host=localhost
 mail.smtp.port=2525
 mail.smtp.ssl.protocols=TLSv1.2
 mail.smtp.ssl.trust=localhost
+
+# Swagger configurations
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui-custom.html

--- a/src/main/java/org/easycontactforms/core/controller/ContactFormController.java
+++ b/src/main/java/org/easycontactforms/core/controller/ContactFormController.java
@@ -1,5 +1,14 @@
 package org.easycontactforms.core.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.easycontactforms.core.pluginloader.PluginStore;
 import org.easycontactforms.core.dtos.ContactFormDto;
 import org.easycontactforms.core.dtos.ErrorDto;
@@ -12,11 +21,11 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
 
 /**
  * Controller for handling contact requests with JSON or XML body
  */
+@Tag(name="contact-submission", description = "All contact submission related endpoints")
 @RestController
 @Slf4j
 @RequestMapping("/contact")
@@ -36,8 +45,21 @@ public class ContactFormController {
      * @param contactFormDto request body
      * @return status and in db saved object
      */
+    @Operation(summary = "Add contact request",
+            parameters = {
+                    @Parameter(in = ParameterIn.HEADER,
+                            name = "authorization",
+                            description = "Optional Authorization via Bearer token",
+                            required = false,
+                            schema = @Schema(type = "string"))})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Created new entry",
+                    content = {@Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ContactForm.class))}),
+            @ApiResponse(responseCode = "400", description = "Invalid request",
+                    content = @Content)})
     @CrossOrigin
-    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE})
+    @PostMapping(consumes = {MediaType.APPLICATION_JSON_VALUE}, produces = {MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity processContactForm(@RequestBody @Valid ContactFormDto contactFormDto){
         return handleRequest(contactFormDto);
     }
@@ -74,4 +96,5 @@ public class ContactFormController {
         log.debug("[POST] successfully processed contact form");
         return ResponseEntity.accepted().body(contactForm);
     }
+
 }

--- a/src/main/java/org/easycontactforms/core/dtos/ContactFormDto.java
+++ b/src/main/java/org/easycontactforms/core/dtos/ContactFormDto.java
@@ -2,15 +2,12 @@ package org.easycontactforms.core.dtos;
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 
 @Data
 @NoArgsConstructor

--- a/src/main/java/org/easycontactforms/core/models/ContactForm.java
+++ b/src/main/java/org/easycontactforms/core/models/ContactForm.java
@@ -6,8 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import java.util.Date;
 
 /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,3 +35,7 @@ spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.generate-ddl=true
 spring.jpa.hibernate.ddl-auto=update
 spring.h2.console.enabled=false
+
+# Swagger configurations
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui-custom.html


### PR DESCRIPTION
Fixes #10 

## Proposed Changes

  - Added the swagger dependencies for api document generation in build.gradle.
  - Added respective annotations for contact api based on the open api specification(enpoints.yaml) 
  - Migrated all the old javax validation to latest jakarta validation (older validation was causing problems with swagger 
dependency)

**Note**

- use https://localhost:8080//api-docs for accessing the open api spec in json format
- use https://localhost:8080//swagger-ui-custom.html for accessing the swagger ui from the browser 
(change the localhost:80 based on the environment in which you are running the application)